### PR TITLE
added ability to change status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 #### Running tests locally:
 
 ## Description:
-Currently has a Welcome page
-There is also a single item visible at `/todo_items/1`
-
+Currently has a Welcome page located at `/`
+There is a single item at `/todo_items/1`
+From the item page you can click on the status (`done` or `not done`) and it will change to whichever it wasn't and update the displayed page
 
 ## Deployment
 This is currently deployed [here](https://todos-kansas-271828.herokuapp.com/)

--- a/app/controllers/todo_items_controller.rb
+++ b/app/controllers/todo_items_controller.rb
@@ -4,6 +4,11 @@ class TodoItemsController < ApplicationController
   def show
   end
 
+  def change_status
+    @todo_item.update_attribute(:is_done, !@todo_item.is_done)
+    redirect_to @todo_item
+  end
+
   private
   def set_todo_item
     @todo_item = TodoItem.find(params[:id])

--- a/app/views/todo_items/show.html.erb
+++ b/app/views/todo_items/show.html.erb
@@ -7,7 +7,7 @@
 <p>
 
 <p>
-  Status: <%= @todo_item.is_done %> 
+  Status: <%= link_to @todo_item.is_done ? "done" : "not done", change_status_todo_item_path(@todo_item.id), method: :patch %> 
 <p>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   resources :todo_items do
+    member do
+      patch :change_status
+    end
   end
 end

--- a/spec/requests/todo_items_spec.rb
+++ b/spec/requests/todo_items_spec.rb
@@ -10,4 +10,15 @@ RSpec.describe 'TodoItems', type: :request do
       expect(response).to render_template('show')
     end
   end
+  
+  it 'changes status' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    patch "/todo_items/#{item1.id}/change_status"
+
+    expect(response).to redirect_to("/todo_items/#{item1.id}")
+    follow_redirect!
+
+    expect(response).to render_template(:show)
+    expect(response.body).to match /not done/
+  end
 end

--- a/spec/views/todo_items/show.html.erb_spec.rb
+++ b/spec/views/todo_items/show.html.erb_spec.rb
@@ -2,10 +2,22 @@ require 'spec_helper'
 
 RSpec.describe "todo_items/show.html.erb" do
 
-  it 'renders passes correct params' do
+  it 'passes correct params' do
     item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny")
     controller.extra_params = { :id => item1.id }
     
     expect(controller.request.fullpath).to eq todo_item_path(item1)
+  end
+
+  it 'renders correct params' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: false)
+    assign(:todo_item, item1)
+    controller.extra_params = { :id => item1.id }
+    
+    render :template => 'todo_items/show.html.erb'
+
+    expect(rendered).to match /Of Mice and Men/
+    expect(rendered).to match /George and Lenny/
+    expect(rendered).to match /not done/
   end
 end


### PR DESCRIPTION
## Summary
the `change-item-status` branch continues to add core functionality for the app:
- ability to change an items status from the item page

## Future Changes
Next steps will be to add the ability to modify the other attributes of a single todo-item (title, description) from the todo-item details page
