### PR TITLE
Update title description

### DIFF
--- a/app/controllers/todo_items_controller.rb
+++ b/app/controllers/todo_items_controller.rb
@@ -4,6 +4,11 @@ class TodoItemsController < ApplicationController
   def show
   end
 
+  def update
+    @todo_item.update!(todo_item_params)
+    redirect_to @todo_item
+  end
+
   def change_status
     @todo_item.update_attribute(:is_done, !@todo_item.is_done)
     redirect_to @todo_item
@@ -15,7 +20,7 @@ class TodoItemsController < ApplicationController
   end
 
   def todo_item_params
-    params[:todo_item].permit(:title, :description, :author, :is_done)
+    params.permit(:title, :description, :author, :is_done)
   end
 
 end

--- a/app/views/todo_items/change_description.html.erb
+++ b/app/views/todo_items/change_description.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <strong>  Updating the description for <%= @todo_item.title %> </strong>
+</p>
+
+<%= form_with(url: todo_item_path, method: "PATCH", model: @todo_item) do |form| %>
+  <%= form.text_area :description %>
+  <%= form.submit "Update" %>
+
+<% end %>
+
+  

--- a/app/views/todo_items/change_title.html.erb
+++ b/app/views/todo_items/change_title.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <strong>  Updating the Title </strong>
+</p>
+
+<%= form_with(url: todo_item_path, method: "PATCH", model: @todo_item) do |form| %>
+  <%= form.text_field :title %>
+  <%= form.submit "Update" %>
+
+<% end %>
+
+  

--- a/app/views/todo_items/show.html.erb
+++ b/app/views/todo_items/show.html.erb
@@ -1,15 +1,18 @@
 <p>
-  <strong>  <%= @todo_item.title %> </strong>
+  <strong> <H1> <%= @todo_item.title %> </h1> </strong>
 </p>
 
+<%= button_to "Update Title", change_title_todo_item_path(@todo_item.id), method: :get %>
+
 <p>
-  Author: <%= @todo_item.author %> 
+<strong>Author:</strong> <%= @todo_item.author %> 
 <p>
 
 <p>
-  Status: <%= link_to @todo_item.is_done ? "done" : "not done", change_status_todo_item_path(@todo_item.id), method: :patch %> 
+  <strong>Status:</strong> <%= link_to @todo_item.is_done ? "done" : "not done", change_status_todo_item_path(@todo_item.id), method: :patch %> 
 <p>
 
-<p>
+<p >
   <%= @todo_item.description %> 
 <p>
+<%= button_to "Update description", change_description_todo_item_path(@todo_item.id), method: :get %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   resources :todo_items do
     member do
       patch :change_status
+      get :change_title
+      get :change_description
     end
   end
 end

--- a/spec/requests/todo_items_spec.rb
+++ b/spec/requests/todo_items_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe 'TodoItems', type: :request do
     expect(response.body).to match /East of Eden/
   end
 
+  it 'shows change description form' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    get "/todo_items/#{item1.id}/change_description"
+
+    expect(response).to render_template(:change_description)
+  end
+
   it 'changes the description on patch request' do
     item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
     patch "/todo_items/#{item1.id}", params: {description: "the Trasks and the Hamiltons"}

--- a/spec/requests/todo_items_spec.rb
+++ b/spec/requests/todo_items_spec.rb
@@ -21,4 +21,29 @@ RSpec.describe 'TodoItems', type: :request do
     expect(response).to render_template(:show)
     expect(response.body).to match /not done/
   end
+
+  it 'shows change title form' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    get "/todo_items/#{item1.id}/change_title"
+
+    expect(response).to render_template(:change_title)
+  end
+
+  it 'changes the title on patch request' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    patch "/todo_items/#{item1.id}", params: {title: "East of Eden"}
+    follow_redirect!
+
+    expect(response).to render_template(:show)
+    expect(response.body).to match /East of Eden/
+  end
+
+  it 'changes the description on patch request' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    patch "/todo_items/#{item1.id}", params: {description: "the Trasks and the Hamiltons"}
+    follow_redirect!
+
+    expect(response).to render_template(:show)
+    expect(response.body).to match /the Trasks and the Hamiltons/
+  end
 end


### PR DESCRIPTION
## Summary
the `update-title-description` branch continues to add core functionality for the app:
- ability to update both title and description from the todo-item page

## Future Changes
Next steps will be to add the author/list page to display all todos for a single author
