### PR TITLE
Add author page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@
 
 ## Description:
 Currently has a Welcome page located at `/`
-There is a single item at `/todo_items/1`
-From the item page you can click on the status (`done` or `not done`) and it will change to whichever it wasn't and update the displayed page
+- There are 2 authors pages located at  `/authors/1` and `/authors/1`
+- There are 4 items (2 per author) located at `/todo_items/1` , `/todo_items/2` , `/todo_items/3` , `/todo_items/4`
+
+From each item page you can click on the status (`done` or `not done`) and it will change to whichever it wasn't and update the displayed page
 
 ## Deployment
 This is currently deployed [here](https://todos-kansas-271828.herokuapp.com/)

--- a/app/assets/stylesheets/authors.scss
+++ b/app/assets/stylesheets/authors.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the authors controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,0 +1,15 @@
+class AuthorsController < ApplicationController
+  before_action :set_author
+  
+  def show
+  end
+
+  private
+    def set_author
+      @author = Author.find(params[:id])
+    end
+
+    def author_params
+      params.require(:author).permit(:name)
+    end
+end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,0 +1,5 @@
+class Author < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true
+  has_many :todo_items
+end

--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -1,5 +1,5 @@
 class TodoItem < ApplicationRecord
-  validates :author, presence: true
+  belongs_to :author
   validates :description, presence: true
   validates :title, presence: true
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <strong>
+    <h1>
+      To Do List for 
+      <%= @author.name %>
+    </h1>
+  </strong>
+</p>
+
+<div id="todo_items_wrapper">
+ <%= render @author.todo_items %>
+</div>

--- a/app/views/todo_items/_todo_item.html.erb
+++ b/app/views/todo_items/_todo_item.html.erb
@@ -1,0 +1,1 @@
+<p><%= todo_item.is_done ? "done" : "not done" %> <%= todo_item.title %></p>

--- a/app/views/todo_items/show.html.erb
+++ b/app/views/todo_items/show.html.erb
@@ -5,7 +5,7 @@
 <%= button_to "Update Title", change_title_todo_item_path(@todo_item.id), method: :get %>
 
 <p>
-<strong>Author:</strong> <%= @todo_item.author %> 
+<strong>Author:</strong> <%= @todo_item.author.name %> 
 <p>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  resources :authors do
+  end
+
   resources :todo_items do
     member do
       patch :change_status

--- a/db/migrate/20210916150950_create_authors.rb
+++ b/db/migrate/20210916150950_create_authors.rb
@@ -1,0 +1,9 @@
+class CreateAuthors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :authors do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210916154741_change_author_to_table.rb
+++ b/db/migrate/20210916154741_change_author_to_table.rb
@@ -1,0 +1,6 @@
+class ChangeAuthorToTable < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :todo_items, :author, :string
+    add_reference :todo_items, :author, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_14_191224) do
+ActiveRecord::Schema.define(version: 2021_09_16_150950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "authors", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "todo_items", force: :cascade do |t|
     t.string "author"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_16_150950) do
+ActiveRecord::Schema.define(version: 2021_09_16_154741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,12 +22,14 @@ ActiveRecord::Schema.define(version: 2021_09_16_150950) do
   end
 
   create_table "todo_items", force: :cascade do |t|
-    t.string "author"
     t.string "title"
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "is_done", default: false
+    t.bigint "author_id", null: false
+    t.index ["author_id"], name: "index_todo_items_on_author_id"
   end
 
+  add_foreign_key "todo_items", "authors"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,38 @@
-TodoItem.create({ author: 'Jack London',
-                  title: 'Explore the wilds',
-                  description: 'I want to get more in touch with nature so that I can write better novels',
-                })
+authors = Author.create(
+    [
+      {name: 'Jack London', id: 1},
+      {name: 'Jane Austen', id: 2}
+    ]
+  )
+
+TodoItem.create(
+    [  
+      { 
+        id: 1,
+        author: authors.first,
+        title: 'Explore the wilds',
+        description: 'I want to get more in touch with nature so that I can write better novels'
+      },
+
+      { 
+        id: 2,
+        author: authors.first,
+        title: 'Get a dog',
+        description: 'I need some animal companionship'
+      },
+
+      { 
+        id: 3,
+        author: authors.second,
+        title: 'go on dates',
+        description: 'It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.'
+      },
+
+      { 
+        id: 4,
+        author: authors.second,
+        title: 'read more books',
+        description: 'The person, be it gentleman or lady, who has not pleasure in a good novel, must be intolerably stupid.'
+      }
+    ]
+  )

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :author do
+    name { "Isaac Asimov" }
+  end
+end

--- a/spec/factories/todo_item.rb
+++ b/spec/factories/todo_item.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :todo_item, class: TodoItem do
-    author { 'Isaac Asimov' }
+    author { association :author }
     title { 'Write "I, Robot"'}
     description { 'How do we program robots?' }
     is_done { false }

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Author, type: :model do
+  subject do
+    described_class.new(name: 'Anne Rice')
+  end
+
+  it "is valid with valid attributes" do
+    expect(subject).to be_valid
+  end
+
+  it "is not valid without a name" do
+    subject.name = nil
+    expect(subject).to_not be_valid
+  end
+
+  it "validates name uniqueness" do
+    subject.save
+    invalid_author = subject.dup
+    expect(invalid_author).to_not be_valid
+  end
+
+  it "has many todo items" do
+    relationship = Author.reflect_on_association(:todo_items)
+    expect(relationship.macro).to eq(:has_many)
+  end
+end

--- a/spec/models/todo_item_spec.rb
+++ b/spec/models/todo_item_spec.rb
@@ -1,26 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe TodoItem, type: :model do
-  subject do
-      described_class.new(author: 'Ethan', title: 'wash the car', description: 'it\'s dirty' )
+  before(:each) do
+    @author1 = Author.new(name: "Isaac Asimov")
   end
+  
 
   it "is valid with valid attributes" do
+    subject = described_class.new(
+      author: @author1,
+      title: "I, Robot",
+      description: "The three laws"
+    )
     expect(subject).to be_valid
   end
 
   it "is not valid without an author" do
-    subject.author = nil
+    subject = described_class.new(
+      author: nil,
+      title: "I, Robot",
+      description: "The three laws"
+    )
     expect(subject).to_not be_valid
   end
 
   it "is not valid without an title" do
-    subject.title = nil
+    subject = described_class.new(
+      author: @author1,
+      title: nil,
+      description: "The three laws"
+    )
     expect(subject).to_not be_valid
   end
 
   it "is not valid without an description" do
-    subject.description = nil
+    subject = described_class.new(
+      author: @author1,
+      title: "I, Robot",
+      description: nil
+    )
     expect(subject).to_not be_valid
   end
   

--- a/spec/requests/authors_spec.rb
+++ b/spec/requests/authors_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Authors", type: :request do
+    before do
+      @author1 = FactoryBot.create(:author, id: 1, name: "Asimov")
+      @todo1 = FactoryBot.create(:todo_item, author: @author1, title: "Foundation")
+  end
+
+  describe 'show page' do
+    it 'should render the show page' do
+      get '/authors/1'
+      expect(response).to render_template('show')
+    end
+
+    it 'should display the authors name and the title of the todo' do
+      get '/authors/1'
+
+      expect(response.body).to match /Asimov/
+      expect(response.body).to match /Foundation/
+
+    end
+  end
+end

--- a/spec/requests/todo_items_spec.rb
+++ b/spec/requests/todo_items_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'TodoItems', type: :request do
   end
   
   it 'changes status' do
-    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    author1 = FactoryBot.create(:author, name: "John Steinbeck")
+    item1 = FactoryBot.create(:todo_item, author: author1, title: "Of Mice and Men", description: "George and Lenny", is_done: true)
     patch "/todo_items/#{item1.id}/change_status"
 
     expect(response).to redirect_to("/todo_items/#{item1.id}")
@@ -23,14 +24,16 @@ RSpec.describe 'TodoItems', type: :request do
   end
 
   it 'shows change title form' do
-    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    author1 = FactoryBot.create(:author, name: "John Steinbeck")
+    item1 = FactoryBot.create(:todo_item, author: author1, title: "Of Mice and Men", description: "George and Lenny", is_done: true)
     get "/todo_items/#{item1.id}/change_title"
 
     expect(response).to render_template(:change_title)
   end
 
   it 'changes the title on patch request' do
-    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    author1 = FactoryBot.create(:author, name: "John Steinbeck")
+    item1 = FactoryBot.create(:todo_item, author: author1, title: "Of Mice and Men", description: "George and Lenny", is_done: true)
     patch "/todo_items/#{item1.id}", params: {title: "East of Eden"}
     follow_redirect!
 
@@ -39,14 +42,16 @@ RSpec.describe 'TodoItems', type: :request do
   end
 
   it 'shows change description form' do
-    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    author1 = FactoryBot.create(:author, name: "John Steinbeck")
+    item1 = FactoryBot.create(:todo_item, author: author1, title: "Of Mice and Men", description: "George and Lenny", is_done: true)
     get "/todo_items/#{item1.id}/change_description"
 
     expect(response).to render_template(:change_description)
   end
 
   it 'changes the description on patch request' do
-    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: true)    
+    author1 = FactoryBot.create(:author, name: "John Steinbeck")
+    item1 = FactoryBot.create(:todo_item, author: author1, title: "Of Mice and Men", description: "George and Lenny", is_done: true)
     patch "/todo_items/#{item1.id}", params: {description: "the Trasks and the Hamiltons"}
     follow_redirect!
 

--- a/spec/views/todo_items/show.html.erb_spec.rb
+++ b/spec/views/todo_items/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "todo_items/show.html.erb" do
 
   it 'passes correct params' do
     item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny")
-    controller.extra_params = { :id => item1.id }
+    controller.extra_params = { id: item1.id }
     
     expect(controller.request.fullpath).to eq todo_item_path(item1)
   end
@@ -12,9 +12,9 @@ RSpec.describe "todo_items/show.html.erb" do
   it 'renders correct params' do
     item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: false)
     assign(:todo_item, item1)
-    controller.extra_params = { :id => item1.id }
+    controller.extra_params = { id: item1.id }
     
-    render :template => 'todo_items/show.html.erb'
+    render(template: 'todo_items/show')
 
     expect(rendered).to match /Of Mice and Men/
     expect(rendered).to match /George and Lenny/


### PR DESCRIPTION
## Summary
the `add-author page` branch continues to add core functionality for the app:
- a page for each author's todos

## Future Changes
connect that page to the individual items