### PR TITLE
can now delete an item

### DIFF
--- a/app/controllers/todo_items_controller.rb
+++ b/app/controllers/todo_items_controller.rb
@@ -1,11 +1,16 @@
 class TodoItemsController < ApplicationController
-  before_action :set_author, only: [:create, :new]
+  before_action :set_author, only: [:create, :new, :destroy]
   before_action :set_todo_item, except: [:create, :new]
 
   def show
   end
 
   def new
+  end
+
+  def destroy
+    @todo_item.destroy
+    redirect_to @author
   end
 
   def create

--- a/app/views/todo_items/show.html.erb
+++ b/app/views/todo_items/show.html.erb
@@ -16,3 +16,8 @@
   <%= @todo_item.description %> 
 <p>
 <%= button_to "Update description", change_description_todo_item_path(@todo_item.id), method: :get %>
+
+<p>
+<%= button_to "Delete Item", todo_item_path(@todo_item), params: {author_id: @todo_item.author.id}, method: :delete, data: {confirm: "Are you sure?"} %>
+
+

--- a/spec/views/todo_items/show.html.erb_spec.rb
+++ b/spec/views/todo_items/show.html.erb_spec.rb
@@ -20,4 +20,15 @@ RSpec.describe "todo_items/show.html.erb" do
     expect(rendered).to match /George and Lenny/
     expect(rendered).to match /not done/
   end
+
+  it 'has a new item button' do
+    item1 = FactoryBot.create(:todo_item, title: "Of Mice and Men", description: "George and Lenny", is_done: false)
+    assign(:todo_item, item1)
+    controller.extra_params = { id: item1.id }
+    
+    render(template: 'todo_items/show')
+
+
+    expect(rendered).to match /Delete Item/
+  end
 end


### PR DESCRIPTION
## Summary
the `delete-item` branch continues to add core functionality for the app:
- ability to delete an item from the item's details page

## Future Changes
Next steps will be to navigate from the list page to a specific todo on that list
