### PR TITLE
added navigation links to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 #### Running tests locally:
 
 ## Description:
-Currently has a Welcome page located at `/` which displays a welcome message and a list of authors names
-- There are 2 authors pages located at  `/authors/1` and `/authors/2`
-From the author pages you can navigate to individual to do items and create a new todo item
+Currently has a Welcome page located at `/` which displays a welcome message and a list of authors names. From this page each authors name will link to that author's todo list
+
+From the author's todo list pages you can navigate to individual to do items and create a new todo item
 
 From each item page you can click on the status (`done` or `not done`) and it will change to whichever it wasn't and update the displayed page. This page also allows updating of title or description and deletion of a todo item
 

--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @authors.each do |author| %>
       <tr>
-        <td><%= author.name %></td>
+        <td><%= link_to author.name, author %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/views/authors/index.html.erb_spec.rb
+++ b/spec/views/authors/index.html.erb_spec.rb
@@ -20,4 +20,15 @@ RSpec.describe "authors/index.html.erb" do
     expect(rendered).to match /Asimov/
     expect(rendered).to match /Heinlen/
   end
+
+  it 'contains links to all authors' do
+    author1 = FactoryBot.create(:author, id: 1, name: "Asimov")
+    author2 = FactoryBot.create(:author, id: 2, name: "Heinlen")
+    assign(:authors, Author.all)
+
+    render
+
+    expect(rendered).to match /a href="\/authors\/1"/
+    expect(rendered).to match /a href="\/authors\/2"/
+  end
 end


### PR DESCRIPTION
## Summary
the `author-navigation` branch updates the welcome/authors page to link to each individual author's todo list page
## Future Changes
Add the ability to create new author from the welcome/authors page