### PR TITLE
added delete author

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## Description:
 Currently has a Welcome page located at `/` which displays a welcome message and a list of authors names. From this page each authors name will link to that author's todo list
 
-From the author's todo list pages you can update the author's name. You can also navigate to individual to do items and create a new todo item
+From the author's todo list pages you can update the author's name or delete the author. Deleting the author deletes all associated todo items. You can also navigate to individual to do items and create a new todo item
 
 From each item page you can click on the status (`done` or `not done`) and it will change to whichever it wasn't and update the displayed page. This page also allows updating of title or description and deletion of a todo item
 

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,5 +1,5 @@
 class AuthorsController < ApplicationController
-  before_action :set_author, only: [ :show, :update, :change_name]
+  before_action :set_author, only: [ :show, :update, :change_name, :destroy]
   
   def show
   end
@@ -7,6 +7,12 @@ class AuthorsController < ApplicationController
   def index
     @authors = Author.all
   end
+
+  def destroy
+    @author.destroy
+    redirect_to '/'
+  end
+
 
   def change_name
   end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,5 @@
 class Author < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true
-  has_many :todo_items
+  has_many :todo_items, dependent: :destroy
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -14,3 +14,4 @@
 </div>
 
 <%= button_to "New Item", new_author_todo_item_path(@author), method: :get %>
+<%= button_to "Delete Author", author_path(@author), method: :delete, data: {confirm: "Are you sure?"} %>

--- a/spec/requests/authors_spec.rb
+++ b/spec/requests/authors_spec.rb
@@ -18,25 +18,26 @@ RSpec.describe "Authors", type: :request do
       expect(response.body).to match /Asimov/
       expect(response.body).to match /Foundation/
     end
-  end
 
-  it 'shows change name form' do
-    author1 = FactoryBot.create(:author, name: "Robert Jordon")
-    get "/authors/#{author1.id}/change_name"
 
-    expect(response).to render_template(:change_name)
-  end
+    it 'shows change name form' do
+      author1 = FactoryBot.create(:author, name: "Robert Jordon")
+      get "/authors/#{author1.id}/change_name"
 
-  it 'changes name on patch request' do
-  author1 = FactoryBot.create(:author, name: "Robert Jordon")
+      expect(response).to render_template(:change_name)
+    end
 
-  patch "/authors/#{author1.id}", params: {
-    author: {name: "Brandon Sanderson"}}
-  follow_redirect!
+    it 'changes name on patch request' do
+      author1 = FactoryBot.create(:author, name: "Robert Jordon")
 
-  expect(response).to render_template(:show)
-  expect(response.body).to match /Brandon Sanderson/
-  expect(response.body).to_not match /Robert Jordon/
+      patch "/authors/#{author1.id}", params: {
+        author: {name: "Brandon Sanderson"}}
+      follow_redirect!
+
+      expect(response).to render_template(:show)
+      expect(response.body).to match /Brandon Sanderson/
+      expect(response.body).to_not match /Robert Jordon/
+    end
   end
 
   describe 'index page' do
@@ -44,7 +45,18 @@ RSpec.describe "Authors", type: :request do
       get '/'
 
       expect(response).to render_template('index')
+    end
 
+    it 'should redirect to the authors index page on author delete' do
+      author1 = FactoryBot.create(:author, name: "Robert Jordon")
+      author2 = FactoryBot.create(:author, name: "Brandon Sanderson")
+
+      delete "/authors/#{author1.id}"
+      follow_redirect!
+
+      expect(response).to render_template(:index)
+      expect(response.body).to match /Brandon Sanderson/
+      expect(response.body).to_not match /Robert Jordon/
     end
   end
 end

--- a/spec/views/authors/show.html.erb_spec.rb
+++ b/spec/views/authors/show.html.erb_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe "authors/show.html.erb" do
     expect(rendered).to match /New Item/
   end
 
+  it 'has a delete author button' do
+    author1 = FactoryBot.create(:author, name: 'George Orwell')
+    assign(:author, author1)
+    controller.extra_params = { id: author1.id }
+    
+    render(template: 'authors/show')
+
+    expect(rendered).to match /Delete Author/
+  end
+
   it 'has a update name button' do
     author1 = FactoryBot.create(:author, name: "Asimov")
     assign(:author, author1)


### PR DESCRIPTION
## Summary
the `delete-author` branch updates the list page  to allow deleting the author.
## Future Changes
Add the ability to create new author from the welcome/authors page